### PR TITLE
User profile show page, and edit profile functionality

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -29,7 +29,7 @@ class UsersController <ApplicationController
       flash[:success] = 'Profile updated'
       redirect_to '/profile'
     else
-      flash[:error] = @user.error.full_messages.uniq.to_sentence
+      flash[:error] = @user.errors.full_messages.uniq.to_sentence
       redirect_to '/profile/edit'
     end
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,7 +4,6 @@ class UsersController <ApplicationController
   end
 
   def create
-
     user = User.new(user_params)
     if user.save
       session[:user_id] = user.id

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -15,12 +15,32 @@ class UsersController <ApplicationController
     end
   end
 
+  def edit
+    @user = User.find(session[:user_id])
+  end
+
   def show
     @user = User.find(session[:user_id])
   end
 
+  def update
+    @user = User.find(session[:user_id])
+    if @user.update(profile_params)
+      flash[:success] = 'Profile updated'
+      redirect_to '/profile'
+    else
+      flash[:error] = @user.error.full_messages.uniq.to_sentence
+      redirect_to '/profile/edit'
+    end
+  end
+
   private
+
   def user_params
     params.require(:user).permit(:name,:address,:city,:state,:zip,:email,:password,:password_confirmation)
+  end
+
+  def profile_params
+    params.require(:users_edit).permit(:name,:address,:city,:state,:zip,:email)
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -26,7 +26,7 @@
             <% else %>
               <%= render partial: "partials/log_in_out", locals: {log_in_out: "Log Out", path: "/logout", message: "Logged in as: ", message_link: "#{User.find(session[:user_id]).name}", message_path: "/profile"} %>
             <% end %>
-        </div> %>
+        </div>
 
       <div id="cart-indicator">
         <%= link_to '/cart', class: 'topnav-link', id: 'cart-link' do %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,0 +1,19 @@
+<center>
+    <h2>Edit Your Profile</h2>
+    <%= form_for :users_edit, method: :patch do |f| %>
+      <%= f.label :name %>
+      <%= f.text_field :name, value: @user.name %>
+      <%= f.label :address %>
+      <%= f.text_field :address, value: @user.address %>
+      <%= f.label :city %>
+      <%= f.text_field :city, value: @user.city %>
+      <%= f.label :state %>
+      <%= f.text_field :state, value: @user.state %>
+      <%= f.label :zip %>
+      <%= f.text_field :zip, value: @user.zip %>
+      <%= f.label :email %>
+      <%= f.email_field :email, value: @user.email %>
+      <%= f.submit 'Update Profile' %>
+  <% end %>
+
+</center>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,0 +1,9 @@
+<section class="user-profile">
+  <h2><%= @user.name %>'s Profile</h2>
+  <p style="font-weight:bold;">Address:</p>
+  <p><%= @user.address %></p>
+  <p><%= "#{@user.city}, #{@user.state} #{@user.zip}" %></p>
+  <p><span style="font-weight:bold;">Email: </span><%= @user.email %></p>
+  <br>
+  <%= link_to 'Edit Profile', '/profile/edit' %>
+</section>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -6,4 +6,5 @@
   <p><span style="font-weight:bold;">Email: </span><%= @user.email %></p>
   <br>
   <%= link_to 'Edit Profile', '/profile/edit' %>
+  <%= link_to 'Change Password', '/profile/edit_password' %>
 </section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,6 +40,9 @@ Rails.application.routes.draw do
   post '/orders', to: 'orders#create'
   get '/orders/:id', to: 'orders#show'
 
-  post "/users", to: "users#create", as: :users
-  get "/profile", to: "users#show"
+  post '/users', to: 'users#create', as: :users
+  get '/profile', to: 'users#show'
+  get '/profile/edit', to: 'users#edit'
+  patch '/profile/edit', to: 'users#update'
+
 end

--- a/spec/features/users/edit_spec.rb
+++ b/spec/features/users/edit_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+describe 'User clicks Edit Profile link in their profile' do
+  it 'Takes them to a prepopulated form to edit their info' do
+    user = create(:user)
+
+    visit '/login'
+
+    within "#login-form" do
+      fill_in 'Email', with: user.email
+      fill_in 'Password', with: user.password
+      click_on 'Log In'
+    end
+
+    click_link 'Edit Profile'
+
+    expect(current_path).to eq('/users/edit')
+
+    click_on 'Update Profile'
+
+    expect(current_path).to eq('/profile')
+
+    click_link 'Edit Profile'
+
+    fill_in 'Name', with: 'Maria'
+    fill_in 'Address', with: '123 A st.'
+    fill_in 'City', with: 'San Pedro'
+    fill_in 'State', with: 'CA'
+    fill_in 'zip', with: '92345'
+    fill_in 'email', with: 'maria@email.com'
+
+    click_on 'Update Profile'
+
+    within '.user-profile' do
+      expect(page).to have_content("Maria's Profile")
+      expect(page).to have_content("123 A st.")
+      expect(page).to have_content("San Pedro, CA 92345")
+      expect(page).to have_content("Email: maria@email.com")
+    end
+  end
+end
+# As a registered user
+# When I visit my profile page
+# I see a link to edit my profile data
+# When I click on the link to edit my profile data
+# I see a form like the registration page
+# The form is prepopulated with all my current information except my password
+# When I change any or all of that information
+# And I submit the form
+# Then I am returned to my profile page
+# And I see a flash message telling me that my data is updated
+# And I see my updated information

--- a/spec/features/users/edit_spec.rb
+++ b/spec/features/users/edit_spec.rb
@@ -14,7 +14,7 @@ describe 'User clicks Edit Profile link in their profile' do
 
     click_link 'Edit Profile'
 
-    expect(current_path).to eq('/users/edit')
+    expect(current_path).to eq('/profile/edit')
 
     click_on 'Update Profile'
 
@@ -26,10 +26,12 @@ describe 'User clicks Edit Profile link in their profile' do
     fill_in 'Address', with: '123 A st.'
     fill_in 'City', with: 'San Pedro'
     fill_in 'State', with: 'CA'
-    fill_in 'zip', with: '92345'
-    fill_in 'email', with: 'maria@email.com'
+    fill_in 'Zip', with: '92345'
+    fill_in 'Email', with: 'maria@email.com'
 
     click_on 'Update Profile'
+
+    expect(page).to have_content('Profile updated')
 
     within '.user-profile' do
       expect(page).to have_content("Maria's Profile")

--- a/spec/features/users/edit_spec.rb
+++ b/spec/features/users/edit_spec.rb
@@ -40,15 +40,30 @@ describe 'User clicks Edit Profile link in their profile' do
       expect(page).to have_content("Email: maria@email.com")
     end
   end
+
+  it 'They cant leave any fields blank in edit form' do
+    user = create(:user)
+
+    visit '/login'
+
+    within "#login-form" do
+      fill_in 'Email', with: user.email
+      fill_in 'Password', with: user.password
+      click_on 'Log In'
+    end
+
+    click_link 'Edit Profile'
+
+    fill_in 'Name', with: nil
+    fill_in 'Address', with: nil
+    fill_in 'City', with: nil
+    fill_in 'State', with: nil
+    fill_in 'Zip', with: nil
+    fill_in 'Email', with: nil
+
+    click_on 'Update Profile'
+
+    expect(current_path).to eq('/profile/edit')
+    expect(page).to have_content("Name can't be blank, Address can't be blank, City can't be blank, State can't be blank, Zip can't be blank, and Email can't be blank")
+  end
 end
-# As a registered user
-# When I visit my profile page
-# I see a link to edit my profile data
-# When I click on the link to edit my profile data
-# I see a form like the registration page
-# The form is prepopulated with all my current information except my password
-# When I change any or all of that information
-# And I submit the form
-# Then I am returned to my profile page
-# And I see a flash message telling me that my data is updated
-# And I see my updated information

--- a/spec/features/users/show_spec.rb
+++ b/spec/features/users/show_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+describe 'User visits their profile page' do
+  it 'Show all their info inlucing edit link' do
+    user = create(:user)
+
+    visit '/login'
+
+    fill_in 'Email', with: user.email
+    fill_in 'Password', with: user.password
+
+    within '#login-form' do
+      click_on 'Log In'
+    end
+    within '.user-profile' do
+      expect(current_path).to eq('/profile')
+
+      expect(page).to have_content("#{user.name}'s Profile")
+      expect(page).to have_content("#{user.address}")
+      expect(page).to have_content("#{user.city}, #{user.state} #{user.zip}")
+      expect(page).to have_content("Email: #{user.email}")
+
+      expect(page).to have_link('Edit Profile')
+    end
+  end
+end
+# As a registered user
+# When I visit my profile page
+# Then I see all of my profile data on the page except my password
+# And I see a link to edit my profile data

--- a/spec/features/users/show_spec.rb
+++ b/spec/features/users/show_spec.rb
@@ -21,10 +21,7 @@ describe 'User visits their profile page' do
       expect(page).to have_content("Email: #{user.email}")
 
       expect(page).to have_link('Edit Profile')
+      expect(page).to have_link('Change Password')
     end
   end
 end
-# As a registered user
-# When I visit my profile page
-# Then I see all of my profile data on the page except my password
-# And I see a link to edit my profile data


### PR DESCRIPTION
- When users log in, or click on their name in the login options, or visit /profile, they are taken to a page that shows all their info except for their password.
- There is also a link to edit their profile info. They can't leave any of it blank.