### PR TITLE
Add password updating functionality, tests pass

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -34,6 +34,28 @@ class UsersController <ApplicationController
     end
   end
 
+  def edit_password
+  end
+
+  def update_password
+    @user = User.find(session[:user_id])
+    if @user.authenticate(params[:update_password][:old_password])
+      if params[:update_password][:new_password] == params[:update_password][:new_password_confirmation]
+        @user.password = params[:update_password][:new_password]
+        @user.save
+        flash[:success] = 'You got a fresh new password, dog!'
+        redirect_to '/profile'
+      else
+        flash[:error] = "Your new password didn't match the confirmation"
+        redirect_to '/profile/edit_password'
+      end
+    else
+      flash[:error] = "Your old password didn't match the one on record"
+      redirect_to '/profile/edit_password'
+    end
+
+  end
+
   private
 
   def user_params

--- a/app/views/users/edit_password.html.erb
+++ b/app/views/users/edit_password.html.erb
@@ -1,0 +1,12 @@
+<center>
+  <br>
+  <%= form_for :update_password, method: :patch do |f| %>
+    <%= f.label :old_password %>
+    <%= f.password_field :old_password %>
+    <%= f.label :new_password %>
+    <%= f.password_field :new_password %>
+    <%= f.label :new_password_confirmation %>
+    <%= f.password_field :new_password_confirmation %>
+    <%= f.submit 'Update Password' %>
+  <% end %>
+</center>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,5 +44,7 @@ Rails.application.routes.draw do
   get '/profile', to: 'users#show'
   get '/profile/edit', to: 'users#edit'
   patch '/profile/edit', to: 'users#update'
+  get '/profile/edit_password', to: 'users#edit_password'
+  patch '/profile/edit_password', to: 'users#update_password'
 
 end

--- a/spec/features/users/edit_password_spec.rb
+++ b/spec/features/users/edit_password_spec.rb
@@ -1,0 +1,75 @@
+require 'rails_helper'
+
+describe 'User clicks Change Password in their profile' do
+  it 'Makes them enter their old password and a new password with confirmation' do
+    user = create(:user)
+
+    visit '/login'
+
+    fill_in 'Email', with: user.email
+    fill_in 'Password', with: user.password
+
+    within '#login-form' do
+      click_on 'Log In'
+    end
+
+    click_link('Change Password')
+
+    fill_in 'Old password', with: user.password
+    fill_in 'New password', with: 'newpass'
+    fill_in 'New password confirmation', with: 'newpass'
+
+    click_on 'Update Password'
+
+    expect(current_path).to eq('/profile')
+    expect(page).to have_content('You got a fresh new password, dog!')
+  end
+
+  it 'Needs to have the correct old password' do
+    user = create(:user)
+
+    visit '/login'
+
+    fill_in 'Email', with: user.email
+    fill_in 'Password', with: user.password
+
+    within '#login-form' do
+      click_on 'Log In'
+    end
+
+    click_link('Change Password')
+
+    fill_in 'Old password', with: 'badpass'
+    fill_in 'New password', with: 'newpass'
+    fill_in 'New password confirmation', with: 'newpass'
+
+    click_on 'Update Password'
+
+    expect(current_path).to eq('/profile/edit_password')
+    expect(page).to have_content("Your old password didn't match the one on record")
+  end
+
+  it 'Needs to have matching new passwords' do
+    user = create(:user)
+
+    visit '/login'
+
+    fill_in 'Email', with: user.email
+    fill_in 'Password', with: user.password
+
+    within '#login-form' do
+      click_on 'Log In'
+    end
+
+    click_link('Change Password')
+
+    fill_in 'Old password', with: user.password
+    fill_in 'New password', with: 'newpass'
+    fill_in 'New password confirmation', with: 'badpass'
+
+    click_on 'Update Password'
+
+    expect(current_path).to eq('/profile/edit_password')
+    expect(page).to have_content("Your new password didn't match the confirmation")
+  end
+end


### PR DESCRIPTION
- User must enter their old password, whose digest must match the password_digest for that user
- Must enter new password and confirmation, which also must match each other
- If successful, user is redirected to their profile and the database is updated with their new password_digest